### PR TITLE
Feature/30 home publishing

### DIFF
--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -20,7 +20,7 @@ export default ({ color, text }: GoalCardPropsType) => {
           borderRadius: 4,
         }}
       >
-        <Text style={{ fontSize: 20, fontWeight: '700', color: platte.gray00, textAlign: 'auto' }}>{text}</Text>
+        <Text style={{ fontSize: 20, fontWeight: '700', color: platte.gray00, textAlign: 'center' }}>{text}</Text>
       </View>
     </TouchableOpacity>
   );

--- a/src/components/ViewAll.tsx
+++ b/src/components/ViewAll.tsx
@@ -1,0 +1,30 @@
+import { View, Text } from 'react-native';
+import CustomButton from './common/CustomButton';
+import { ReactNode } from 'react';
+import { platte } from '@/styles/platte';
+
+interface ViewAllProps {
+  title: string;
+  children?: ReactNode;
+}
+
+export default ({ title, children }: ViewAllProps) => {
+  return (
+    <View
+      style={{
+        padding: 12,
+        borderRadius: 12,
+        flexDirection: 'column',
+        gap: 8,
+        borderColor: platte.gray10,
+        borderWidth: 1,
+      }}
+    >
+      <View style={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+        <Text style={{ fontSize: 20, fontWeight: '700' }}>{title}</Text>
+        <CustomButton title="모두 보기" size="S" onPress={() => {}} />
+      </View>
+      {children}
+    </View>
+  );
+};

--- a/src/screens/Goal.tsx
+++ b/src/screens/Goal.tsx
@@ -9,8 +9,13 @@ const Goal = () => {
       <PageTitle title="모든 목표" />
       <View style={{ paddingHorizontal: 16, gap: 16 }}>
         <CustomButton title="+  새 목표 만들기" size="M" />
-        <View style={{ gap: 12, flexWrap: 'wrap' }}>
-          <GoalCard text="관광통역안내사 취득" color="#339988" />
+        <View style={{ gap: 12, flexWrap: 'wrap', flexDirection: 'row', justifyContent: 'space-between' }}>
+          <View style={{ width: '48%' }}>
+            <GoalCard text="관광통역안내사 취득" color="#339988" />
+          </View>
+          <View style={{ width: '48%' }}>
+            <GoalCard text="관광통역안내사 취득" color="#339988" />
+          </View>
         </View>
       </View>
     </>

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -25,6 +25,7 @@ const Home = () => {
         <ViewAll title="즐겨찾기한 목표">
           <FlatList
             style={{ width: '100%', gap: 20 }}
+            scrollEnabled={false}
             data={[
               { text: '관광통역안내사 취득', color: '#339988' },
               { text: '관광통역안내사 취득', color: '#339988' },

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,7 +1,46 @@
-import { Text } from 'react-native';
+import GoalCard from '@/components/GoalCard';
+import PageTitle from '@/components/PageTitle';
+import ViewAll from '@/components/ViewAll';
+import GoalCheck from '@/components/common/GoalCheck';
+import MeetCard from '@/components/common/MeetCard';
+import { RootStackParam } from '@/utils/RootStackParam';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { FlatList, ScrollView, Text, View } from 'react-native';
 
 const Home = () => {
-  return <Text>홈</Text>;
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
+
+  return (
+    <ScrollView>
+      <PageTitle title="홈" />
+      <View style={{ flexDirection: 'column', gap: 12, paddingHorizontal: 16 }}>
+        <GoalCheck />
+        <ViewAll title="이런 모임도 있어요">
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+            <MeetCard />
+            <MeetCard />
+          </View>
+        </ViewAll>
+        <ViewAll title="즐겨찾기한 목표">
+          <FlatList
+            style={{ width: '100%', gap: 20 }}
+            data={[
+              { text: '관광통역안내사 취득', color: '#339988' },
+              { text: '관광통역안내사 취득', color: '#339988' },
+              { text: '관광통역안내사 취득', color: '#339988' },
+            ]}
+            renderItem={({ item }) => (
+              <View style={{ width: '46%', margin: '2%' }}>
+                <GoalCard text={item.text} color={item.color} />
+              </View>
+            )}
+            numColumns={2}
+          />
+        </ViewAll>
+      </View>
+    </ScrollView>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
## 작업 대상
홈 화면 퍼블리싱

## 📄 작업 내용

- 홈화면에 달성 기록 컴포넌트 배치
- 모두 보기 컴포넌트 제작
- 모임, 즐겨 찾기 목표 추가
- FlatList 경고문을 수정

## 🙋🏻 주의 사항

- React Native에는 grid를 사용할 수 없어서 목표 카드 배치 방법을 수정하였습니다.(간격을 gap으로 주지 않고 margin으로 줌)

## 스크린샷
<img width="346" alt="스크린샷 2023-11-14 오후 11 45 55" src="https://github.com/ILYDSM/ILY-FE/assets/102665117/81ad3327-84e9-4894-818b-1b2e69feefc8">

## 📎 관련 이슈

close #30 

## 레퍼런스
https://deemmun.tistory.com/46
https://velog.io/@xedni/Lab-React-Native-VirtualizedLists-should-never-be-nested-inside-plain-ScrollViews