### PR TITLE
keyboard refactoring

### DIFF
--- a/src/screens/ChangePwd.tsx
+++ b/src/screens/ChangePwd.tsx
@@ -1,58 +1,75 @@
 import CustomButton from '@/components/common/CustomButton';
 import TitleBar from '@/components/common/TitleBar';
-import { View, Text } from 'react-native';
+import { View, Text, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParam } from '@/utils/RootStackParam';
+import { useEffect, useState } from "react";
 import { useForm, Controller } from 'react-hook-form';
 import CustomInput from '@/components/common/CustomInput';
 import { platte } from '@/styles/platte';
 
 export default () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
   const { control, handleSubmit } = useForm({
     defaultValues: {
       email: '',
     },
   });
 
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar title="비밀번호 변경" onPress={() => navigation.goBack()} />
-      <View
-        style={{
-          flex: 1,
-          width: '100%',
-          paddingHorizontal: 16,
-          gap: 20,
-        }}
-      >
-        <Text style={{ color: platte.gray100, fontSize: 16, fontWeight: '500' }}>
-          본인 확인을 위해 가입할 때 사용한 이메일 인증이 필요해요
-        </Text>
-        <View style={{ flexDirection: 'column', gap: 20 }}>
-          <Controller
-            control={control}
-            name="email"
-            rules={{
-              required: true,
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar title="비밀번호 변경" onPress={() => navigation.goBack()} />
+        <View
+          style={{
+            flex: 1,
+            width: '100%',
+            paddingHorizontal: 16,
+            gap: 20,
+          }}
+        >
+          <Text style={{ color: platte.gray100, fontSize: 16, fontWeight: '500' }}>
+            본인 확인을 위해 가입할 때 사용한 이메일 인증이 필요해요
+          </Text>
+          <View style={{ flexDirection: 'column', gap: 20 }}>
+            <Controller
+              control={control}
+              name="email"
+              rules={{
+                required: true,
+              }}
+              render={({ field: { onChange, value } }) => (
+                <CustomInput text="이메일" onChangeText={onChange} value={value} autoComplete="email" />
+              )}
+            />
+          </View>
+        </View>
+        <View style={{ width: '100%', paddingHorizontal: 16, paddingBottom: keyboardStatus ? 0 : 16 }}>
+          <CustomButton
+            title="→ 다음"
+            onPress={() => {
+              // handleSubmit(onSubmit);
+              navigation.navigate('VerifyEmail');
             }}
-            render={({ field: { onChange, value } }) => (
-              <CustomInput text="이메일" onChangeText={onChange} value={value} autoComplete="email" />
-            )}
           />
         </View>
-      </View>
-      <View style={{ width: '100%', paddingHorizontal: 16 }}>
-        <CustomButton
-          title="→ 다음"
-          onPress={() => {
-            // handleSubmit(onSubmit);
-            navigation.navigate('VerifyEmail');
-          }}
-        />
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/screens/CreateGroup.tsx
+++ b/src/screens/CreateGroup.tsx
@@ -7,47 +7,64 @@ import { platte } from '@/styles/platte';
 import { RootStackParam } from '@/utils/RootStackParam';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Text, View, StyleSheet, ScrollView } from 'react-native';
+import { Text, View, StyleSheet, ScrollView, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { useState, useEffect } from "react";
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const CreateGroup = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
+
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar title="새 모임 만들기" onPress={() => navigation.goBack()} />
-      <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 20 }}>
-        <CustomInput text="이름" />
-        <View style={{ gap: 8 }}>
-          <CustomSwitch text="최대 인원 제한" />
-          <CustomInput text="인원 제한" icon={<Text style={styles.unit}>명</Text>} />
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar title="새 모임 만들기" onPress={() => navigation.goBack()} />
+        <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 20 }}>
+          <CustomInput text="이름" />
+          <View style={{ gap: 8 }}>
+            <CustomSwitch text="최대 인원 제한" />
+            <CustomInput text="인원 제한" icon={<Text style={styles.unit}>명</Text>} />
+          </View>
+          <CustomInput
+            text="설명"
+            description={`모임을 설명할 수 있는 간단한 소갯말을 작성해 주세요\n14자까지 작성할 수 있어요`}
+          />
+          <View>
+            <ScrollView
+              horizontal
+              contentContainerStyle={{
+                columnGap: 8,
+              }}
+            >
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+              <Category text="스포츠" />
+            </ScrollView>
+          </View>
         </View>
-        <CustomInput
-          text="설명"
-          description={`모임을 설명할 수 있는 간단한 소갯말을 작성해 주세요\n14자까지 작성할 수 있어요`}
-        />
-        <View>
-          <ScrollView
-            horizontal
-            contentContainerStyle={{
-              columnGap: 8,
-            }}
-          >
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-            <Category text="스포츠" />
-          </ScrollView>
+        <View style={{ width: '100%', paddingHorizontal: 16, paddingBottom: keyboardStatus ? 0 : 16 }}>
+          <CustomButton title="→ 다음" />
         </View>
-      </View>
-      <View style={{ width: '100%', paddingHorizontal: 16 }}>
-        <CustomButton title="→ 다음" />
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/screens/Group.tsx
+++ b/src/screens/Group.tsx
@@ -9,49 +9,51 @@ import { RootStackParam } from '@/utils/RootStackParam';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Search } from 'lucide-react-native';
-import { Text, View, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { Text, View, StyleSheet, FlatList, TouchableOpacity, Keyboard, TouchableWithoutFeedback } from 'react-native';
 
 const Group = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
 
   return (
-    <>
-      <PageTitle title="모임" />
-      <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 16 }}>
-        <CustomInput
-          text="검색"
-          placeholder="모임찾기"
-          icon={
-            <TouchableOpacity onPress={() => navigation.navigate('Group', { screen: 'SearchResult' })}>
-              <Search size={20} color={platte.gray50} />
-            </TouchableOpacity>
-          }
-        />
-        <CustomButton
-          title="관심사별 보기"
-          size="M"
-          color="Gray"
-          onPress={() => navigation.navigate('Group', { screen: 'GroupCategory' })}
-        />
-        <CustomButton
-          title="+ 새 모임 만들기"
-          size="M"
-          color="Black"
-          onPress={() => navigation.navigate('Group', { screen: 'CreateGroup' })}
-        />
-        <Text style={styles.recommendText}>추천 모임</Text>
-        <FlatList
-          data={DATA}
-          renderItem={({ item }) => (
-            <>
-              <MeetCard title={item.title} description={item.description} headCount={item.headCount} />
-              <Margin height={16} />
-            </>
-          )}
-          keyExtractor={(item) => item.id}
-        />
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <View style={{ flex: 1 }}>
+        <PageTitle title="모임" />
+        <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 16 }}>
+          <CustomInput
+            text="검색"
+            placeholder="모임찾기"
+            icon={
+              <TouchableOpacity onPress={() => navigation.navigate('Group', { screen: 'SearchResult' })}>
+                <Search size={20} color={platte.gray50} />
+              </TouchableOpacity>
+            }
+          />
+          <CustomButton
+            title="관심사별 보기"
+            size="M"
+            color="Gray"
+            onPress={() => navigation.navigate('Group', { screen: 'GroupCategory' })}
+          />
+          <CustomButton
+            title="+ 새 모임 만들기"
+            size="M"
+            color="Black"
+            onPress={() => navigation.navigate('Group', { screen: 'CreateGroup' })}
+          />
+          <Text style={styles.recommendText}>추천 모임</Text>
+          <FlatList
+            data={DATA}
+            renderItem={({ item }) => (
+              <>
+                <MeetCard title={item.title} description={item.description} headCount={item.headCount} />
+                <Margin height={16} />
+              </>
+            )}
+            keyExtractor={(item) => item.id}
+          />
+        </View>
       </View>
-    </>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -4,11 +4,11 @@ import TitleBar from '@/components/common/TitleBar';
 import { RootStackParam } from '@/utils/RootStackParam';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Text, View, TouchableOpacity } from 'react-native';
+import { Text, View, TouchableOpacity, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { EyeOff, Eye } from 'lucide-react-native';
 import { platte } from '@/styles/platte';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import KakaoButton from '@/components/AuthButtons/KakaoButton';
 import GoogleButton from '@/components/AuthButtons/GoogleButton';
 import NaverButton from '@/components/AuthButtons/NaverButton';
@@ -16,7 +16,7 @@ import { useForm, Controller } from 'react-hook-form';
 
 const Login = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
-
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
   const [isPasswordOpen, setIsPasswordOpen] = useState(false);
 
   const handlePasswordEye = () => {
@@ -39,111 +39,126 @@ const Login = () => {
     navigation.navigate('Main');
   };
 
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar
-        title="로그인"
-        onPress={() => {
-          navigation.navigate('Rending');
-        }}
-      />
-      <View
-        style={{
-          flex: 1,
-          width: '100%',
-          justifyContent: 'center',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
-        <View style={{ width: '90%', flex: 9 }}>
-          <View style={{ flexDirection: 'column', gap: 20 }}>
-            <Controller
-              control={control}
-              rules={{
-                required: { value: true, message: '이메일은 필수입니다' },
-                pattern: {
-                  value: /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i,
-                  message: '이메일 형식이 아닙니다.',
-                },
-              }}
-              render={({ field: { onChange, value } }) => (
-                <CustomInput
-                  text="이메일"
-                  onChangeText={onChange}
-                  value={value}
-                  isError={!!errors.email}
-                  description={errors.email?.message}
-                />
-              )}
-              name="email"
-            />
-            <Controller
-              control={control}
-              rules={{
-                required: true,
-                minLength: 8,
-                maxLength: 20,
-                pattern: /^(?=.*[a-zA-Z])(?=.*\d).+$/,
-              }}
-              render={({ field: { onChange, value } }) => (
-                <CustomInput
-                  text="비밀번호"
-                  description={
-                    !!errors.secret_key?.message
-                      ? errors.secret_key?.message
-                      : '8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요'
-                  }
-                  icon={
-                    <TouchableOpacity onPress={handlePasswordEye}>
-                      {isPasswordOpen ? (
-                        <Eye color={platte.gray100} size={20} />
-                      ) : (
-                        <EyeOff color={platte.gray100} size={20} />
-                      )}
-                    </TouchableOpacity>
-                  }
-                  onChangeText={onChange}
-                  value={value}
-                  secureTextEntry={!isPasswordOpen}
-                  isError={!!errors.secret_key}
-                />
-              )}
-              name="secret_key"
-            />
-            <Text style={{ textAlign: 'center', fontSize: 16, fontWeight: '700' }}>다른 계정으로 시작하기</Text>
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 8,
-              }}
-            >
-              <KakaoButton />
-              <NaverButton />
-              <GoogleButton />
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar
+          title="로그인"
+          onPress={() => {
+            navigation.navigate('Rending');
+          }}
+        />
+        <View
+          style={{
+            flex: 1,
+            width: '100%',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <View style={{ width: '90%', flex: 9 }}>
+            <View style={{ flexDirection: 'column', gap: 20 }}>
+              <Controller
+                control={control}
+                rules={{
+                  required: { value: true, message: '이메일은 필수입니다' },
+                  pattern: {
+                    value: /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i,
+                    message: '이메일 형식이 아닙니다.',
+                  },
+                }}
+                render={({ field: { onChange, value } }) => (
+                  <CustomInput
+                    text="이메일"
+                    onChangeText={onChange}
+                    value={value}
+                    isError={!!errors.email}
+                    description={errors.email?.message}
+                  />
+                )}
+                name="email"
+              />
+              <Controller
+                control={control}
+                rules={{
+                  required: true,
+                  minLength: 8,
+                  maxLength: 20,
+                  pattern: /^(?=.*[a-zA-Z])(?=.*\d).+$/,
+                }}
+                render={({ field: { onChange, value } }) => (
+                  <CustomInput
+                    text="비밀번호"
+                    description={
+                      !!errors.secret_key?.message
+                        ? errors.secret_key?.message
+                        : '8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요'
+                    }
+                    icon={
+                      <TouchableOpacity onPress={handlePasswordEye}>
+                        {isPasswordOpen ? (
+                          <Eye color={platte.gray100} size={20} />
+                        ) : (
+                          <EyeOff color={platte.gray100} size={20} />
+                        )}
+                      </TouchableOpacity>
+                    }
+                    onChangeText={onChange}
+                    value={value}
+                    secureTextEntry={!isPasswordOpen}
+                    isError={!!errors.secret_key}
+                  />
+                )}
+                name="secret_key"
+              />
+              <Text style={{ textAlign: 'center', fontSize: 16, fontWeight: '700' }}>다른 계정으로 시작하기</Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 8,
+                }}
+              >
+                <KakaoButton />
+                <NaverButton />
+                <GoogleButton />
+              </View>
             </View>
           </View>
+          <View style={{ width: '90%', marginBottom: keyboardStatus ? 0 : 16 }}>
+            <TouchableOpacity onPress={() => navigation.navigate('ChangePwd')}>
+              <Text
+                style={{
+                  textAlign: 'center',
+                  paddingHorizontal: 20,
+                  paddingVertical: 16,
+                  fontSize: 16,
+                  fontWeight: '400',
+                }}
+              >
+                비밀번호 바꾸기
+              </Text>
+            </TouchableOpacity>
+            <CustomButton title="로그인" onPress={handleSubmit(onSubmit)} />
+          </View>
         </View>
-        <View style={{ width: '90%' }}>
-          <TouchableOpacity onPress={() => navigation.navigate('ChangePwd')}>
-            <Text
-              style={{
-                textAlign: 'center',
-                paddingHorizontal: 20,
-                paddingVertical: 16,
-                fontSize: 16,
-                fontWeight: '400',
-              }}
-            >
-              비밀번호 바꾸기
-            </Text>
-          </TouchableOpacity>
-          <CustomButton title="로그인" onPress={handleSubmit(onSubmit)} />
-        </View>
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/screens/NewPassword.tsx
+++ b/src/screens/NewPassword.tsx
@@ -4,17 +4,18 @@ import TitleBar from '@/components/common/TitleBar';
 import { platte } from '@/styles/platte';
 import { Controller, useForm } from 'react-hook-form';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParam } from '@/utils/RootStackParam';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react-native';
 
 type EyeType = { password: boolean; new_password: boolean };
 
 export default () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
 
   const { control, handleSubmit } = useForm({
     defaultValues: {
@@ -32,76 +33,91 @@ export default () => {
     setIsOpen((prev) => ({ ...prev, [type]: !prev[type] }));
   };
 
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar onPress={() => navigation.goBack()} title="새 비밀번호 입력" />
-      <View
-        style={{
-          flex: 1,
-          width: '100%',
-          paddingHorizontal: 16,
-          gap: 20,
-        }}
-      >
-        <View style={{ flexDirection: 'column', gap: 20 }}>
-          <Controller
-            control={control}
-            name="password"
-            rules={{
-              required: true,
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar onPress={() => navigation.goBack()} title="새 비밀번호 입력" />
+        <View
+          style={{
+            flex: 1,
+            width: '100%',
+            paddingHorizontal: 16,
+            gap: 20,
+          }}
+        >
+          <View style={{ flexDirection: 'column', gap: 20 }}>
+            <Controller
+              control={control}
+              name="password"
+              rules={{
+                required: true,
+              }}
+              render={({ field: { onChange, value } }) => (
+                <CustomInput
+                  text="기존 비밀번호"
+                  onChangeText={onChange}
+                  value={value}
+                  icon={
+                    <TouchableOpacity onPress={() => handlePasswordEye('password')}>
+                      {isOpen.password ? (
+                        <Eye color={platte.gray100} size={20} />
+                      ) : (
+                        <EyeOff color={platte.gray100} size={20} />
+                      )}
+                    </TouchableOpacity>
+                  }
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="new_password"
+              rules={{
+                required: true,
+              }}
+              render={({ field: { onChange, value } }) => (
+                <CustomInput
+                  text="새 비밀번호"
+                  description="8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요"
+                  onChangeText={onChange}
+                  value={value}
+                  icon={
+                    <TouchableOpacity onPress={() => handlePasswordEye('new_password')}>
+                      {isOpen.new_password ? (
+                        <Eye color={platte.gray100} size={20} />
+                      ) : (
+                        <EyeOff color={platte.gray100} size={20} />
+                      )}
+                    </TouchableOpacity>
+                  }
+                />
+              )}
+            />
+          </View>
+        </View>
+        <View style={{ width: '100%', paddingHorizontal: 16, paddingBottom: keyboardStatus ? 0 : 16 }}>
+          <CustomButton
+            title="→ 다음"
+            onPress={() => {
+              // handleSubmit(onSubmit);
+              navigation.reset({ routes: [{ name: 'ConfirmChangePwd' }] });
             }}
-            render={({ field: { onChange, value } }) => (
-              <CustomInput
-                text="기존 비밀번호"
-                onChangeText={onChange}
-                value={value}
-                icon={
-                  <TouchableOpacity onPress={() => handlePasswordEye('password')}>
-                    {isOpen.password ? (
-                      <Eye color={platte.gray100} size={20} />
-                    ) : (
-                      <EyeOff color={platte.gray100} size={20} />
-                    )}
-                  </TouchableOpacity>
-                }
-              />
-            )}
-          />
-          <Controller
-            control={control}
-            name="new_password"
-            rules={{
-              required: true,
-            }}
-            render={({ field: { onChange, value } }) => (
-              <CustomInput
-                text="새 비밀번호"
-                description="8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요"
-                onChangeText={onChange}
-                value={value}
-                icon={
-                  <TouchableOpacity onPress={() => handlePasswordEye('new_password')}>
-                    {isOpen.new_password ? (
-                      <Eye color={platte.gray100} size={20} />
-                    ) : (
-                      <EyeOff color={platte.gray100} size={20} />
-                    )}
-                  </TouchableOpacity>
-                }
-              />
-            )}
           />
         </View>
-      </View>
-      <View style={{ width: '100%', paddingHorizontal: 16 }}>
-        <CustomButton
-          title="→ 다음"
-          onPress={() => {
-            // handleSubmit(onSubmit);
-            navigation.reset({ routes: [{ name: 'ConfirmChangePwd' }] });
-          }}
-        />
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/screens/SearchResult.tsx
+++ b/src/screens/SearchResult.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Search } from 'lucide-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { TouchableOpacity, View, Text, ScrollView, FlatList } from 'react-native';
+import { TouchableOpacity, View, Text, ScrollView, FlatList, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { platte } from '@/styles/platte';
 import Category from '@/components/common/Category';
 import MeetCard from '@/components/common/MeetCard';
@@ -16,44 +16,46 @@ const SearchResult = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar title="검색 결과" onPress={() => navigation.goBack()} />
-      <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 16 }}>
-        <CustomInput
-          text="검색"
-          placeholder="모임찾기"
-          icon={
-            <TouchableOpacity onPress={() => {}}>
-              <Search size={20} color={platte.gray50} />
-            </TouchableOpacity>
-          }
-        />
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-          <Text style={{ color: platte.gray50, fontSize: 16, fontWeight: '500' }}>분류</Text>
-          <View>
-            <ScrollView
-              horizontal
-              contentContainerStyle={{
-                columnGap: 8,
-              }}
-            >
-              <Category text="스포츠" />
-              <Category text="스포츠" />
-            </ScrollView>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar title="검색 결과" onPress={() => navigation.goBack()} />
+        <View style={{ flex: 1, width: '100%', paddingHorizontal: 16, gap: 16 }}>
+          <CustomInput
+            text="검색"
+            placeholder="모임찾기"
+            icon={
+              <TouchableOpacity onPress={() => { }}>
+                <Search size={20} color={platte.gray50} />
+              </TouchableOpacity>
+            }
+          />
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            <Text style={{ color: platte.gray50, fontSize: 16, fontWeight: '500' }}>분류</Text>
+            <View>
+              <ScrollView
+                horizontal
+                contentContainerStyle={{
+                  columnGap: 8,
+                }}
+              >
+                <Category text="스포츠" />
+                <Category text="스포츠" />
+              </ScrollView>
+            </View>
           </View>
+          <FlatList
+            data={DATA}
+            renderItem={({ item }) => (
+              <>
+                <MeetCard title={item.title} description={item.description} headCount={item.headCount} />
+                <Margin height={16} />
+              </>
+            )}
+            keyExtractor={(item) => item.id}
+          />
         </View>
-        <FlatList
-          data={DATA}
-          renderItem={({ item }) => (
-            <>
-              <MeetCard title={item.title} description={item.description} headCount={item.headCount} />
-              <Margin height={16} />
-            </>
-          )}
-          keyExtractor={(item) => item.id}
-        />
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/screens/SignUp.tsx
+++ b/src/screens/SignUp.tsx
@@ -3,48 +3,63 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParam } from '@/utils/RootStackParam';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import CustomInput from '@/components/common/CustomInput';
 import CustomButton from '@/components/common/CustomButton';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react-native';
 import { platte } from '@/styles/platte';
 
 const SignUp = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
-
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
   const [isPasswordOpen, setIsPasswordOpen] = useState(false);
 
   const handlePasswordEye = () => {
     setIsPasswordOpen((prev) => !prev);
   };
 
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar
-        title="회원가입 "
-        onPress={() => {
-          navigation.navigate('Rending');
-        }}
-      />
-      <View style={{ flex: 1, paddingHorizontal: 16, gap: 20 }}>
-        <CustomInput text="이메일" />
-        <CustomInput
-          text="비밀번호"
-          description="8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요"
-          icon={
-            <TouchableOpacity onPress={handlePasswordEye}>
-              {isPasswordOpen ? <Eye color={platte.gray100} size={20} /> : <EyeOff color={platte.gray100} size={20} />}
-            </TouchableOpacity>
-          }
-          secureTextEntry={!isPasswordOpen}
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar
+          title="회원가입 "
+          onPress={() => {
+            navigation.navigate('Rending');
+          }}
         />
-        <CustomInput text="닉네임" description="최대 10글자까지 입력할 수 있어요" />
-      </View>
-      <View style={{ paddingHorizontal: 16 }}>
-        <CustomButton title="→ 다음" onPress={() => navigation.navigate('SelectInterest')} />
-      </View>
-    </SafeAreaView>
+        <View style={{ flex: 1, paddingHorizontal: 16, gap: 20 }}>
+          <CustomInput text="이메일" />
+          <CustomInput
+            text="비밀번호"
+            description="8~20자 이내, 알파벳 대소문자, 숫자를 포함해야 해요"
+            icon={
+              <TouchableOpacity onPress={handlePasswordEye}>
+                {isPasswordOpen ? <Eye color={platte.gray100} size={20} /> : <EyeOff color={platte.gray100} size={20} />}
+              </TouchableOpacity>
+            }
+            secureTextEntry={!isPasswordOpen}
+          />
+          <CustomInput text="닉네임" description="최대 10글자까지 입력할 수 있어요" />
+        </View>
+        <View style={{ paddingHorizontal: 16, paddingBottom: keyboardStatus ? 0 : 16 }}>
+          <CustomButton title="→ 다음" onPress={() => navigation.navigate('SelectInterest')} />
+        </View>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/screens/VerifyEmail.tsx
+++ b/src/screens/VerifyEmail.tsx
@@ -4,72 +4,90 @@ import TitleBar from '@/components/common/TitleBar';
 import { platte } from '@/styles/platte';
 import { Controller, useForm } from 'react-hook-form';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { useState, useEffect } from "react";
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParam } from '@/utils/RootStackParam';
 
 export default () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParam>>();
+  const [keyboardStatus, setKeyboardStatus] = useState<boolean>(false);
 
   const { control, handleSubmit } = useForm({
     defaultValues: {
       verify_number: '',
     },
   });
+
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardStatus(true)
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardStatus(false)
+    });
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TitleBar onPress={() => navigation.goBack()} title="이메일 인증" />
-      <View
-        style={{
-          flex: 1,
-          width: '100%',
-          paddingHorizontal: 16,
-          gap: 20,
-        }}
-      >
-        <Text style={{ color: platte.gray100, fontSize: 16, fontWeight: '500' }}>
-          mang5jelly@email.com로 인증 번호가 담긴 이메일을 보냈어요. ◾◾◾안에 입력해 주세요
-        </Text>
-        <View style={{ flexDirection: 'column', gap: 20 }}>
-          <Controller
-            control={control}
-            name="verify_number"
-            rules={{
-              required: true,
-            }}
-            render={({ field: { onChange, value } }) => (
-              <CustomInput text="인증 번호" onChangeText={onChange} value={value} />
-            )}
-          />
-          <View>
-            <CustomButton title="메일 앱 열기" size="M" />
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TitleBar onPress={() => navigation.goBack()} title="이메일 인증" />
+        <View
+          style={{
+            flex: 1,
+            width: '100%',
+            paddingHorizontal: 16,
+            gap: 20,
+          }}
+        >
+          <Text style={{ color: platte.gray100, fontSize: 16, fontWeight: '500' }}>
+            mang5jelly@email.com로 인증 번호가 담긴 이메일을 보냈어요. ◾◾◾안에 입력해 주세요
+          </Text>
+          <View style={{ flexDirection: 'column', gap: 20 }}>
+            <Controller
+              control={control}
+              name="verify_number"
+              rules={{
+                required: true,
+              }}
+              render={({ field: { onChange, value } }) => (
+                <CustomInput text="인증 번호" onChangeText={onChange} value={value} />
+              )}
+            />
+            <View>
+              <CustomButton title="메일 앱 열기" size="M" />
+            </View>
           </View>
         </View>
-      </View>
-      <View style={{ width: '100%', paddingHorizontal: 16 }}>
-        <TouchableOpacity onPress={() => {}}>
-          <Text
-            style={{
-              textAlign: 'center',
-              paddingHorizontal: 20,
-              paddingVertical: 16,
-              color: platte.gray100,
-              fontSize: 16,
-              fontWeight: '400',
+        <View style={{ width: '100%', paddingHorizontal: 16, paddingBottom: keyboardStatus ? 0 : 16 }}>
+          <TouchableOpacity onPress={() => { }}>
+            <Text
+              style={{
+                textAlign: 'center',
+                paddingHorizontal: 20,
+                paddingVertical: 16,
+                color: platte.gray100,
+                fontSize: 16,
+                fontWeight: '400',
+              }}
+            >
+              문제가 생겼나요?
+            </Text>
+          </TouchableOpacity>
+          <CustomButton
+            title="→ 다음"
+            onPress={() => {
+              // handleSubmit(onSubmit);
+              navigation.navigate('NewPassword');
             }}
-          >
-            문제가 생겼나요?
-          </Text>
-        </TouchableOpacity>
-        <CustomButton
-          title="→ 다음"
-          onPress={() => {
-            // handleSubmit(onSubmit);
-            navigation.navigate('NewPassword');
-          }}
-        />
-      </View>
-    </SafeAreaView>
+          />
+        </View>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
CustomInput이 들어가 있는 모든 페이지
<!-- 작업한 대상을 자세히 설명해주세요. -->

## 📄 작업 내용
CustomInput과 keyboard가 아닌 영역을 눌렀을 시 keyboard가 없어지게 하였다.
CustomButton이 아래와 너무 붙어있기에 react-native의 keyboard를 활용하여 paddingBottom을 주었다.
<!-- 작업한 내용을 간단히 요약해주세요. -->

## 🙋🏻 주의 사항
이 코드 Android 기준의 코드입니다.
iOS는 다르게 적용될 수도 있습니다.
한 번 확인해주시면 감사할 것 같습니다.
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
![image](https://github.com/ILYDSM/ILY-FE/assets/103089628/ececff1c-e5be-459e-98f3-608ddc7ad834)
input이 아닌 영역을 눌렀을 때 keyboard를 내리게 하는 부분

![image](https://github.com/ILYDSM/ILY-FE/assets/103089628/c2c3a7cc-58da-440a-a466-e6db4d990566)
keyboard가 켜져있는지 확인할 수 있는 코드입니다.

![image](https://github.com/ILYDSM/ILY-FE/assets/103089628/613d9334-2045-478a-adf4-4d0ca9c325c9)
다음은 바뀐 SignUp 페이지 코드의 일부분입니다.
keyboard가 켜져있으면 padding이 사라져 keyboard와 붙어있게 만들어줍니다.

<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈

<!-- merge 시 close할 issue 번호를 입력해주세요. -->
#20 
<!-- closed #번호 -->

## 레퍼런스
https://medium.com/@binarydiver/react-native-dismiss-keyboard-23ddafbb981d
https://coding-hwije.tistory.com/53
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
